### PR TITLE
Revise download.py against PEP8/flake8 reccomendations

### DIFF
--- a/pysheng/download.py
+++ b/pysheng/download.py
@@ -31,8 +31,10 @@ import lib
 
 AGENT = "Chrome 5.0"
 
+
 class ParsingError(Exception):
     pass
+
 
 def get_id_from_string(s):
     """Return book ID from a string (can be a book code or URL)."""
@@ -41,40 +43,49 @@ def get_id_from_string(s):
     url = s
     match = re.search("[?&]?id=([^&]+)", url)
     if not match:
-        raise ParsingError, "Error extracting id query string from URL: %s" % url
+        raise ParsingError('Error extracting id query string from URL: %s' %
+                           url)
     return match.group(1)
+
 
 def get_cover_url(book_id):
     url = "http://books.google.com/books"
-    return "%s?id=%s&hl=en&printsec=frontcover&source=gbs_ge_summary_r&cad=0" % (url, book_id)
+    return "%s?id=%s&hl=en&printsec=frontcover&source=gbs_ge_summary_r&cad=0" \
+           % (url, book_id)
+
 
 def get_unescape_entities(s):
     parser = HTMLParser.HTMLParser()
     return parser.unescape(s)
 
+
 def get_info(cover_html):
-    """Return dictionary with the book info (prefix, page_ids, title, attribution)."""
+    """Return dictionary with the book information.
+
+    Include the prefix, page_ids, title and attribution."""
     tag = lib.first(s for s in cover_html.split("<")
-        if re.search('input[^>]*\s+name="?ie"?', s))
+                    if re.search('input[^>]*\s+name="?ie"?', s))
     if tag:
         match = re.search('value="(.*?)"', tag)
         if not match:
-            raise ParsingError, "Cannot found encoding info"
+            raise ParsingError('Cannot find encoding info')
         encoding = match.group(1).lower()
     else:
         encoding = "iso8859-15"
     match = re.search(r'_OC_Run\((.*?)\);', cover_html)
     if not match:
-        raise ParsingError, "No JS function OC_Run() found in HTML"
+        raise ParsingError('No JS function OC_Run() found in HTML')
     oc_run_args = json.loads("[%s]" % match.group(1), encoding=encoding)
     if len(oc_run_args) < 2:
-        raise ParsingError, "Expecting at least 2 arguments in function OC_Run()"
+        raise ParsingError('Expecting at least 2 arguments in function: '
+                           'OC_Run()')
     pages_info, book_info = oc_run_args[:2]
     if "page" not in pages_info:
-      raise ParsingError, "Cannot found page info"
-    page_ids = [x["pid"] for x in sorted(pages_info["page"], key=lambda d: d["order"])]
+        raise ParsingError('Cannot find page info')
+    page_ids = [x["pid"] for x in sorted(pages_info["page"],
+                                         key=lambda d: d["order"])]
     if not page_ids:
-        raise ParsingError, "No page_ids found"
+        raise ParsingError('No page_ids found')
     prefix = pages_info["prefix"].decode("raw_unicode_escape")
     mw = book_info["max_resolution_image_width"]
     mh = book_info["max_resolution_image_height"]
@@ -82,9 +93,11 @@ def get_info(cover_html):
         "prefix": prefix,
         "page_ids": page_ids,
         "title": get_unescape_entities(book_info["title"]),
-        "attribution": get_unescape_entities(re.sub("^By\s+", "", book_info["attribution"])),
+        "attribution": get_unescape_entities(re.sub("^By\s+", "",
+                                                    book_info["attribution"])),
         "max_resolution": (mw, mh),
     }
+
 
 def get_image_url_from_page(html):
     """Get image from a page html."""
@@ -93,21 +106,25 @@ def get_image_url_from_page(html):
     else:
         match = re.search(r"preloadImg.src = '([^']*?)'", html)
         if not match:
-            raise ParsingError, "No image found in HTML page"
+            raise ParsingError('No image found in HTML page')
         else:
             return match.group(1).decode("string-escape")
+
 
 def get_page_url(prefix, page_id):
     return prefix + "&pg=" + page_id
 
+
 def download(*args, **kwargs):
     return lib.download(*args, **dict(kwargs, agent=AGENT))
+
 
 def get_info_from_url(url):
     opener = lib.get_cookies_opener()
     cover_url = get_cover_url(get_id_from_string(url))
     cover_html = download(cover_url, opener=opener)
     return get_info(cover_html)
+
 
 def download_book(url, page_start=0, page_end=None):
     """Yield tuples (info, page, image_data) for each page of the book
@@ -127,6 +144,7 @@ def download_book(url, page_start=0, page_end=None):
             image_data = download(image_url, opener=opener)
             yield info, page, image_data
 
+
 def main(args):
     import optparse
     usage = """usage: %prog GOOGLE_BOOK_OR_ID
@@ -134,15 +152,15 @@ def main(args):
     Download a Google Book and create a PNG image for each page."""
     parser = optparse.OptionParser(usage)
     parser.add_option('-s', '--page-start', dest='page_start', type="int",
-        default=1, help='Start page')
+                      default=1, help='Start page')
     parser.add_option('-e', '--page-end', dest='page_end', type="int",
-        default=None, help='End page')
+                      default=None, help='End page')
     parser.add_option('-n', '--no-redownload', dest='noredownload',
-        action="store_true", default=False,
-        help='Do not download pages if they exist')
+                      action="store_true", default=False,
+                      help='Do not download pages if they exist')
     parser.add_option('-q', '--quiet', dest='quiet',
-        action="store_true", default=False,
-        help='Do not print messages to the terminal')
+                      action="store_true", default=False,
+                      help='Do not print messages to the terminal')
     options, pargs = parser.parse_args(args)
     if not pargs:
         parser.print_usage()
@@ -165,6 +183,7 @@ def main(args):
                 print 'Downloaded {}'.format(output_path)
         elif not options.quiet:
             print 'Output file {} exists'.format(output_path)
+
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
A cleanup of a plain run of flake8 against download.py
the test seems to run w/o issue and downloads still work.

Per #22 

Here is the `flake8` output pre houskeeping:
```
download.py:34:1: E302 expected 2 blank lines, found 1
download.py:37:1: E302 expected 2 blank lines, found 1
download.py:44:27: W602 deprecated form of raising exception
download.py:44:80: E501 line too long (81 > 79 characters)
download.py:47:1: E302 expected 2 blank lines, found 1
download.py:49:80: E501 line too long (94 > 79 characters)
download.py:51:1: E302 expected 2 blank lines, found 1
download.py:55:1: E302 expected 2 blank lines, found 1
download.py:56:80: E501 line too long (86 > 79 characters)
download.py:58:9: E128 continuation line under-indented for visual indent
download.py:62:31: W602 deprecated form of raising exception
download.py:68:27: W602 deprecated form of raising exception
download.py:71:27: W602 deprecated form of raising exception
download.py:71:80: E501 line too long (81 > 79 characters)
download.py:74:7: E111 indentation is not a multiple of four
download.py:74:25: W602 deprecated form of raising exception
download.py:75:80: E501 line too long (87 > 79 characters)
download.py:77:27: W602 deprecated form of raising exception
download.py:85:80: E501 line too long (93 > 79 characters)
download.py:89:1: E302 expected 2 blank lines, found 1
download.py:96:31: W602 deprecated form of raising exception
download.py:100:1: E302 expected 2 blank lines, found 1
download.py:103:1: E302 expected 2 blank lines, found 1
download.py:106:1: E302 expected 2 blank lines, found 1
download.py:112:1: E302 expected 2 blank lines, found 1
download.py:130:1: E302 expected 2 blank lines, found 1
download.py:137:9: E128 continuation line under-indented for visual indent
download.py:139:9: E128 continuation line under-indented for visual indent
download.py:141:9: E128 continuation line under-indented for visual indent
download.py:142:9: E128 continuation line under-indented for visual indent
download.py:144:9: E128 continuation line under-indented for visual indent
download.py:145:9: E128 continuation line under-indented for visual indent
download.py:169:1: E305 expected 2 blank lines after class or function definition, found 1

```
