### PR TITLE
changed user agent to bypass connection reset by peer

### DIFF
--- a/pysheng/lib.py
+++ b/pysheng/lib.py
@@ -53,7 +53,8 @@ def first(iterable, pred=bool):
             return item
 
 
-def download(url, opener=None, agent='Mozilla/5.0 (X11; U; Linux x86_64)'):
+#def download(url, opener=None, agent='Mozilla/5.0 (X11; U; Linux x86_64)'):
+def download(url, opener=None, agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36'):
     """Download a URL, optionally using a urlib2.opener"""
     opener = opener or urllib2.build_opener()
     request = (url if isinstance(url, urllib2.Request) else build_request(url))


### PR DESCRIPTION
hi! I can't download a book using the old user agent with the following error:
`
Exception in thread Thread-6:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/franco/.local/lib/python2.7/site-packages/pysheng/asyncjobs.py", line 399, in _thread_manager
    request, size = connect_opener(self.url, self.opener, self.headers)
  File "/home/franco/.local/lib/python2.7/site-packages/pysheng/asyncjobs.py", line 318, in connect_opener
    response = opener.open(request)
  File "/usr/lib/python2.7/urllib2.py", line 429, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 447, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1241, in https_open
    context=self._context)
  File "/usr/lib/python2.7/urllib2.py", line 1198, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 104] Connection reset by peer>

Traceback (most recent call last):
  File "/home/franco/.local/lib/python2.7/site-packages/pysheng/asyncjobs.py", line 129, in _advance_task_cb
    self._advance_task_step(generator, method, result)
  File "/home/franco/.local/lib/python2.7/site-packages/pysheng/asyncjobs.py", line 139, in _advance_task_step
    new_task = getattr(generator, method)(result)
  File "/home/franco/.local/lib/python2.7/site-packages/pysheng/yieldfrom.py", line 47, in _process
    new_tosend = (yield yielded)
urllib2.URLError: <urlopen error [Errno 104] Connection reset by peer>
`

I changed the user agent as suggested [here](https://stackoverflow.com/questions/41255134/python3-connection-reset-by-peer?rq=1). Afterwards I downloaded a book with success.